### PR TITLE
Added GetSidekickTableForRole Function + Resolved Wrong Color Problem for TargetID + Corpse Icon

### DIFF
--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -275,7 +275,6 @@ else -- CLIENT
 	
 	local function GetDarkenMateColor(ply)
 		ply = ply or LocalPlayer()
-
 		if IsValid(ply) and ply.GetSubRole and ply:GetSubRole() and ply:GetSubRole() == ROLE_SIDEKICK then
 			local col
 			local deadSubRole = ply.lastMateSubRole
@@ -299,13 +298,27 @@ else -- CLIENT
 	hook.Add("TTTScoreboardRowColorForPlayer", "ModifySikiSBColor", GetDarkenMateColor)
 	hook.Add("TTT2ModifyWeaponColors", "SikiModifyWeaponColors", GetDarkenMateColor)
 	hook.Add("TTT2ModifyRoleBGColor", "SikiModifyRoleBGColor", GetDarkenMateColor)
-
+	hook.Add("TTT2ModifyTargetIDColor", "SikiModifyTargetIDColor", GetDarkenMateColor)
+	
 	hook.Add("TTT2ModifyRoleIconColor", "SikiModifyRoleIconColors", function(ply)
 		local col = GetDarkenMateColor(ply)
 		if col then
 			col.a = 200
 
 			return col
+		end
+	end)
+	
+	hook.Add("TTT2ModifyBodyFoundRoleIcon", "SikiModifyBodyFoundRoleIcon", function(nick)
+		local ply = nil
+		for _, v in ipairs(player.GetAll()) do
+			if v:Nick() == nick then
+				ply = v
+			end
+		end	
+		
+		if IsValid(ply) then
+			return GetDarkenMateColor(ply)
 		end
 	end)
 end

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -308,7 +308,7 @@ else -- CLIENT
 		return GetDarkenMateColor(ply, "bgcolor")
 	end)
 	
-	hook.Add("TTT2ModifyBodyFoundRoleIcon", "SikiModifyBodyFoundRoleIcon", function(nick)
+	hook.Add("TTT2ModifyBodyFoundRoleColor", "SikiModifyBodyFoundRoleIcon", function(nick)
 		local ply = nil
 		for _, v in ipairs(player.GetAll()) do
 			if v:Nick() == nick then

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -75,7 +75,13 @@ end
 
 local function tmpfnc(ply, mate, colorTable)
 	if IsValid(mate) and mate:IsPlayer() then
-		return table.Copy(select(2, pcall(mate[colorTable], mate)))
+		if colorTable == "dkcolor" then
+			return table.Copy(mate:GetRoleDkColor())
+		elseif colorTable == "bgcolor" then
+			return table.Copy(mate:GetRoleBgColor())
+		elseif colorTable == "color" then
+			return table.Copy(mate:GetRoleColor())
+		end
 	elseif ply.mateSubRole then
 		return table.Copy(GetRoleByIndex(ply.mateSubRole)[colorTable])
 	end
@@ -98,7 +104,7 @@ local function GetDarkenMateColor(ply, colorTable)
 		else
 			col = tmpfnc(ply, mate, colorTable)
 		end
-
+		
 		return GetDarkenColor(col)
 	end
 end
@@ -282,17 +288,17 @@ else -- CLIENT
 	
 	-- Modify colors
 	hook.Add("TTT2ModifyRoleDkColor", "SikiModifyRoleDkColor", function(ply)
-		return GetDarkenMateColor(ply, "GetRoleDkColor")
+		return GetDarkenMateColor(ply, "dkcolor")
 	end)
 
 	hook.Add("TTT2ModifyRoleBgColor", "SikiModifyRoleBgColor", function(ply)
-		return GetDarkenMateColor(ply, "GetRoleBgColor")
+		return GetDarkenMateColor(ply, "bgcolor")
 	end)
 end
 
 --modify role colors on both client and server
 hook.Add("TTT2ModifyRoleColor", "SikiModifyRoleColor", function(ply)
-	return GetDarkenMateColor(ply, "GetRoleColor")
+	return GetDarkenMateColor(ply, "color")
 end)
 
 hook.Add("TTTPrepareRound", "SikiPrepareRound", function()

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -57,22 +57,20 @@ if CLIENT then
 	end)
 end
 
-
-local function GetDarkenColor(color)
+function GetDarkenColor(color)
+	if not istable(color) then return end
 	local col = table.Copy(color)
-	if col then
-		-- darken color
-		for _, v in ipairs{"r", "g", "b"} do
-			col[v] = col[v] - 60
-			if col[v] < 0 then
-				col[v] = 0
-			end
+	-- darken color
+	for _, v in ipairs{"r", "g", "b"} do
+		col[v] = col[v] - 60
+		if col[v] < 0 then
+			col[v] = 0
 		end
-
-		col.a = 255
-
-		return col
 	end
+
+	col.a = 255
+
+	return col
 end
 
 function plymeta:IsSidekick()
@@ -101,19 +99,6 @@ function plymeta:GetSidekicks()
 	end
 
 	return tmp
-end
-
-function GetSidekickTableForRole(role)
-	if role != nil then
-		local siki_deagle = GetEquipmentByName("weapon_ttt2_sidekickdeagle")
-		if istable(siki_deagle) and istable(siki_deagle.CanBuy) and table.HasValue(siki_deagle.CanBuy, role.index) then
-			local siki_mod_table =  table.Copy(GetRoleByIndex(ROLE_SIDEKICK))
-			siki_mod_table.color = GetDarkenColor(role.color)
-			siki_mod_table.dkcolor = GetDarkenColor(role.dkcolor)
-			siki_mod_table.bgcolor = GetDarkenColor(role.bgcolor)
-			return siki_mod_table
-		end
-	end
 end
 
 function HealPlayer(ply)

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -265,16 +265,17 @@ else -- CLIENT
 		end
 	end)
 
-	local function tmpfnc(ply, mate)
+	local function tmpfnc(ply, mate, colorTable)
 		if IsValid(mate) and mate:IsPlayer() then
-			return table.Copy(mate:GetSubRoleData().color)
+			return table.Copy(mate:GetSubRoleData()[colorTable])
 		elseif ply.mateSubRole then
-			return table.Copy(GetRoleByIndex(ply.mateSubRole).color)
+			return table.Copy(GetRoleByIndex(ply.mateSubRole)[colorTable])
 		end
 	end
 	
-	local function GetDarkenMateColor(ply)
+	local function GetDarkenMateColor(ply, colorTable)
 		ply = ply or LocalPlayer()
+
 		if IsValid(ply) and ply.GetSubRole and ply:GetSubRole() and ply:GetSubRole() == ROLE_SIDEKICK then
 			local col
 			local deadSubRole = ply.lastMateSubRole
@@ -282,12 +283,12 @@ else -- CLIENT
 
 			if not ply:Alive() and deadSubRole then
 				if IsValid(mate) and mate:IsPlayer() and mate:IsInTeam(ply) and not mate:GetSubRoleData().unknownTeam then
-					col = tmpfnc(ply, mate)
+					col = tmpfnc(ply, mate, colorTable)
 				else
-					col = table.Copy(GetRoleByIndex(deadSubRole).color)
+					col = table.Copy(GetRoleByIndex(deadSubRole)[colorTable])
 				end
 			else
-				col = tmpfnc(ply, mate)
+				col = tmpfnc(ply, mate, colorTable)
 			end
 			
 			return GetDarkenColor(col)
@@ -295,18 +296,16 @@ else -- CLIENT
 	end
 
 	-- Modify colors
-	hook.Add("TTTScoreboardRowColorForPlayer", "ModifySikiSBColor", GetDarkenMateColor)
-	hook.Add("TTT2ModifyWeaponColors", "SikiModifyWeaponColors", GetDarkenMateColor)
-	hook.Add("TTT2ModifyRoleBGColor", "SikiModifyRoleBGColor", GetDarkenMateColor)
-	hook.Add("TTT2ModifyTargetIDColor", "SikiModifyTargetIDColor", GetDarkenMateColor)
-	
-	hook.Add("TTT2ModifyRoleIconColor", "SikiModifyRoleIconColors", function(ply)
-		local col = GetDarkenMateColor(ply)
-		if col then
-			col.a = 200
+	hook.Add("TTT2ModifyRoleColor", "SikiModifyRoleColor", function(ply)
+		return GetDarkenMateColor(ply, "color")
+	end)
 
-			return col
-		end
+	hook.Add("TTT2ModifyRoleDkColor", "SikiModifyRoleDkColor", function(ply)
+		return GetDarkenMateColor(ply, "dkcolor")
+	end)
+
+	hook.Add("TTT2ModifyRoleBgColor", "SikiModifyRoleBgColor", function(ply)
+		return GetDarkenMateColor(ply, "bgcolor")
 	end)
 	
 	hook.Add("TTT2ModifyBodyFoundRoleIcon", "SikiModifyBodyFoundRoleIcon", function(nick)
@@ -318,7 +317,7 @@ else -- CLIENT
 		end	
 		
 		if IsValid(ply) then
-			return GetDarkenMateColor(ply)
+			return ply:GetRoleColor()
 		end
 	end)
 end

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -104,7 +104,7 @@ function plymeta:GetSidekicks()
 end
 
 function GetSidekickTableForRole(role)
-	if role != nil && istable(SYNC_EQUIP) then
+	if role != nil then
 		local siki_deagle = GetEquipmentByName("weapon_ttt2_sidekickdeagle")
 		if istable(siki_deagle) and istable(siki_deagle.CanBuy) and table.HasValue(siki_deagle.CanBuy, role.index) then
 			local siki_mod_table =  table.Copy(GetRoleByIndex(ROLE_SIDEKICK))

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -292,19 +292,6 @@ else -- CLIENT
 	hook.Add("TTT2ModifyRoleBgColor", "SikiModifyRoleBgColor", function(ply)
 		return GetDarkenMateColor(ply, "bgcolor")
 	end)
-	
-	hook.Add("TTT2ModifyBodyFoundRoleColor", "SikiModifyBodyFoundRoleIcon", function(nick)
-		local ply = nil
-		for _, v in ipairs(player.GetAll()) do
-			if v:Nick() == nick then
-				ply = v
-			end
-		end	
-		
-		if IsValid(ply) then
-			return ply:GetRoleColor()
-		end
-	end)
 end
 
 hook.Add("TTTPrepareRound", "SikiPrepareRound", function()

--- a/gamemodes/terrortown/entities/entities/sidekick/shared.lua
+++ b/gamemodes/terrortown/entities/entities/sidekick/shared.lua
@@ -75,7 +75,7 @@ end
 
 local function tmpfnc(ply, mate, colorTable)
 	if IsValid(mate) and mate:IsPlayer() then
-		return table.Copy(mate:GetSubRoleData()[colorTable])
+		return table.Copy(select(2, pcall(mate[colorTable], mate)))
 	elseif ply.mateSubRole then
 		return table.Copy(GetRoleByIndex(ply.mateSubRole)[colorTable])
 	end
@@ -98,7 +98,7 @@ local function GetDarkenMateColor(ply, colorTable)
 		else
 			col = tmpfnc(ply, mate, colorTable)
 		end
-		
+
 		return GetDarkenColor(col)
 	end
 end
@@ -282,17 +282,17 @@ else -- CLIENT
 	
 	-- Modify colors
 	hook.Add("TTT2ModifyRoleDkColor", "SikiModifyRoleDkColor", function(ply)
-		return GetDarkenMateColor(ply, "dkcolor")
+		return GetDarkenMateColor(ply, "GetRoleDkColor")
 	end)
 
 	hook.Add("TTT2ModifyRoleBgColor", "SikiModifyRoleBgColor", function(ply)
-		return GetDarkenMateColor(ply, "bgcolor")
+		return GetDarkenMateColor(ply, "GetRoleBgColor")
 	end)
 end
 
 --modify role colors on both client and server
 hook.Add("TTT2ModifyRoleColor", "SikiModifyRoleColor", function(ply)
-	return GetDarkenMateColor(ply, "color")
+	return GetDarkenMateColor(ply, "GetRoleColor")
 end)
 
 hook.Add("TTTPrepareRound", "SikiPrepareRound", function()


### PR DESCRIPTION
implemented GetSidekickTableForRole function which returns the possible sidekick role table for a role (including correct colors) or nil if no sidekick is possible

-this will be used for Weapons like Manipulation Knife/Death Faker, which need the possible role distribution and not the current one