### PR TITLE
Better Sidekick Deagle Shot Handling

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
@@ -117,13 +117,10 @@ local function SidekickDeagleCallback(attacker, tr, dmg)
 	if IsValid(deagle) then
 		deagle:Remove()
 	end
-
 	AddSidekick(target, attacker)
-
+	
 	net.Start("tttSidekickMSG")
-
 	net.WriteEntity(target)
-
 	net.Send(attacker)
 
 	return true

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
@@ -55,7 +55,7 @@ SWEP.Primary.DefaultClip = 1
 
 -- some other stuff
 SWEP.InLoadoutFor = nil
-SWEP.AllowDrop = true
+SWEP.AllowDrop = false
 SWEP.IsSilent = false
 SWEP.NoSights = false
 SWEP.UseHands = true

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt2_sidekickdeagle.lua
@@ -17,6 +17,7 @@ if SERVER then
 	util.AddNetworkString("tttSidekickMSG")
 	util.AddNetworkString("tttSidekickRefillCDReduced")
 	util.AddNetworkString("tttSidekickDeagleRefilled")
+	util.AddNetworkString("tttSidekickDeagleMiss")
 else
 	hook.Add("Initialize", "TTTInitSikiDeagleLang", function()
 		LANG.AddToLanguage("English", "ttt2_weapon_sidekickdeagle_desc", "Shoot a player to make him your sidekick.")
@@ -44,7 +45,7 @@ SWEP.Primary.Delay = 1
 SWEP.Primary.Recoil = 6
 SWEP.Primary.Automatic = false
 SWEP.Primary.NumShots = 1
-SWEP.Primary.Damage = 1
+SWEP.Primary.Damage = 0
 SWEP.Primary.Cone = 0.00001
 SWEP.Primary.Ammo = ""
 SWEP.Primary.ClipSize = 1
@@ -53,7 +54,7 @@ SWEP.Primary.DefaultClip = 1
 
 -- some other stuff
 SWEP.InLoadoutFor = nil
-SWEP.AllowDrop = false
+SWEP.AllowDrop = true
 SWEP.IsSilent = false
 SWEP.NoSights = false
 SWEP.UseHands = true
@@ -90,21 +91,62 @@ local function SidekickDeagleRefilled(wep)
 	net.SendToServer()
 end
 
+local function SidekickDeagleCallback(attacker, tr, dmg)
+	if CLIENT then return end
+
+	local target = tr.Entity
+
+	--invalid shot return
+	if not GetRoundState() == ROUND_ACTIVE or not IsValid(attacker) or not attacker:IsTerror() then return end
+
+	--no/bad hit: (send message), start timer and return
+	if not IsValid(target) or not target:IsTerror() or target:GetSubRole() == ROLE_JACKAL or target:GetSubRole() == ROLE_SIDEKICK then
+		if IsValid(target) and (target:GetSubRole() == ROLE_JACKAL or target:GetSubRole() == ROLE_SIDEKICK) then
+			attacker:PrintMessage(HUD_PRINTTALK, "You can't shoot a Jackal/Sidekick as Sidekick!")
+		end	
+		if ttt2_sidekick_deagle_refill_conv:GetBool() then
+			net.Start("tttSidekickDeagleMiss")
+			net.Send(attacker)
+		end
+		return
+	end
+
+	local deagle = attacker:GetWeapon("weapon_ttt2_sidekickdeagle")
+	if IsValid(deagle) then
+		deagle:Remove()
+	end
+
+	AddSidekick(target, attacker)
+
+	net.Start("tttSidekickMSG")
+
+	net.WriteEntity(target)
+
+	net.Send(attacker)
+
+	return true
+end
+
 function SWEP:OnDrop()
 	self:Remove()
 end
 
-function SWEP:PrimaryAttack()
-	if CLIENT and self:CanPrimaryAttack() and ttt2_sidekick_deagle_refill_conv:GetBool() then
-		local initialCD = ttt2_sidekick_deagle_refill_cd_conv:GetInt()
+function SWEP:ShootBullet(dmg, recoil, numbul, cone)
+	cone = cone or 0.01
+	
+	local bullet = {}
+	bullet.Num = 1
+	bullet.Src = self:GetOwner():GetShootPos()
+	bullet.Dir = self:GetOwner():GetAimVector()
+	bullet.Spread = Vector(cone, cone, 0)
+	bullet.Tracer = 0
+	bullet.TracerName = self.Tracer or "Tracer"
+	bullet.Force = 10
+	bullet.Damage = 0
+	bullet.Callback = SidekickDeagleCallback
+	self:GetOwner():FireBullets(bullet)
 
-		STATUS:AddTimedStatus("ttt2_sidekick_deagle_reloading", initialCD, true) 
-		timer.Create("ttt2_sidekick_deagle_refill_timer", initialCD, 1, function()
-			SidekickDeagleRefilled(self)
-		end)
-	end
-
-	self.BaseClass.PrimaryAttack(self)
+	self.BaseClass.ShootBullet(self, dmg, recoil, numbul, cone)
 end
 
 function SWEP:OnRemove()
@@ -137,21 +179,6 @@ end
 
 
 if SERVER then
-	hook.Add("ScalePlayerDamage", "SidekickHitReg", function(ply, hitgroup, dmginfo)
-		local attacker = dmginfo:GetAttacker()
-		if GetRoundState() ~= ROUND_ACTIVE or not attacker or not IsValid(attacker)
-			or not attacker:IsPlayer() or not IsValid(attacker:GetActiveWeapon()) then return end
-
-		local weap = attacker:GetActiveWeapon()
-
-		if weap:GetClass() ~= "weapon_ttt2_sidekickdeagle" then return end
-
-		ShootSidekick(ply, dmginfo)
-		weap:Remove()
-		dmginfo:SetDamage(0)
-		return true
-	end)
-
 	hook.Add("PlayerDeath", "SidekickDeagleRefillReduceCD", function(victim, inflictor, attacker)
 		if IsValid(attacker) and attacker:IsPlayer() and attacker:HasWeapon("weapon_ttt2_sidekickdeagle") and ttt2_sidekick_deagle_refill_conv:GetBool() then
 			net.Start("tttSidekickRefillCDReduced")
@@ -184,9 +211,6 @@ if CLIENT then
 		STATUS:RegisterStatus("ttt2_sidekick_deagle_reloading", {
 			hud = Material("vgui/ttt/hud_icon_deagle.png"),
 			type = "bad"
-			--,
-
-			--DrawInfo = function(self) return tostring(math.Round(math.max(0, self.displaytime - CurTime()))) end
 		})
 	end)
 
@@ -214,6 +238,19 @@ if CLIENT then
 		local text = LANG.GetParamTranslation("ttt2_siki_ply_killed", {amount = ttt2_siki_deagle_refill_cd_per_kill_conv:GetInt()})
 		MSTACK:AddMessage(text)
 		chat.PlaySound()
+	end)
+
+	net.Receive("tttSidekickDeagleMiss", function()
+		local client = LocalPlayer()
+		if not IsValid(client) or not client:IsTerror() or not client:HasWeapon("weapon_ttt2_sidekickdeagle") then return end
+
+		local wep = client:GetWeapon("weapon_ttt2_sidekickdeagle")
+		local initialCD = ttt2_sidekick_deagle_refill_cd_conv:GetInt()
+
+		STATUS:AddTimedStatus("ttt2_sidekick_deagle_reloading", initialCD, true) 
+		timer.Create("ttt2_sidekick_deagle_refill_timer", initialCD, 1, function()
+			SidekickDeagleRefilled(wep)
+		end)	
 	end)
 else
 	net.Receive("tttSidekickDeagleRefilled", function()


### PR DESCRIPTION
* Replaces the usage of the ScaleDamage hook with a bullet callback, so that the currently active weapon is no longer used (closes #6 )
* Usage of the callback for better status handling

* Generalization for "same team" case